### PR TITLE
remove export no longer needed

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -68,7 +68,6 @@ echo "dbms.default_database=amr" >> $CONF_FILE
 
 (${CONDA_DIR}/neo4j-community/bin/neo4j start && sleep 20) | grep "Started neo4j"
 
-export PATH=/srv/conda/notebook/bin:$PATH
 python $HOME/src/amr-script.py
 
 ${CONDA_DIR}/neo4j-community/bin/neo4j stop


### PR DESCRIPTION
The export command is no longer needed since the env is active at that point.
